### PR TITLE
Implements pip integration task

### DIFF
--- a/bolt.pyproj
+++ b/bolt.pyproj
@@ -22,6 +22,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="about.py" />
+    <Compile Include="tasks\bolt_pip.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="tasks\delete_files.py">
       <SubType>Code</SubType>
     </Compile>

--- a/bolt/tasks/__init__.py
+++ b/bolt/tasks/__init__.py
@@ -2,7 +2,9 @@
 """
 # Import tasks modules here.
 #
+import bolt_pip
 import delete_files
 
 def register_standard_modules(registry):
+    bolt_pip.register_tasks(registry)
     delete_files.register_tasks(registry)

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -8,38 +8,43 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 class _PipArgumentGenerator(object):
 
     DEFAULT_ARGUMENTS = [DEFAULT_COMMAND, '-r', DEFAULT_REQUIREMENTS_FILE]
+    TO_ENABLE_FLAG = True
+    TO_DISABLE_FLAG = False
     
     def generate_from(self, config):
         if not config:
             return self.DEFAULT_ARGUMENTS
         self.config = config
-        return self._process_config()
+        return self._convert_config_to_arguments()
 
 
-    def _process_config(self):
+    def _convert_config_to_arguments(self):
         self.command = self.config.get('command')
         self.package = self.config.get('package')
-        if self._installing_single_package():
-            return [DEFAULT_COMMAND, self.package]
-        else:
-            self.generated_args = []
-            self.generated_args.append(self.command)
-            self._process_options()
-            return self.generated_args
+        return [DEFAULT_COMMAND, self.package] if self._installing_single_package else self._converted_options
+            
 
+    @property
     def _installing_single_package(self):
         return self.command == DEFAULT_COMMAND and self.package
 
-
-    def _process_options(self):
+    @property
+    def _converted_options(self):
+        self.args = [self.command]
         self.options = self.config.get('options')
-        for option, value in self.options.iteritems():
-            formatted_option = self._format_option(option)
-            if value:
-                self.generated_args.append(formatted_option)
-                if value is not True:
-                    self.generated_args.append(value)
+        {self._push_as_arguments(option, value) for option, value in self.options.iteritems()}       
+        return self.args
 
+    def _push_as_arguments(self, option, value):
+        if value is not self.TO_DISABLE_FLAG:
+            self._do_push(option, value)        
+
+
+    def _do_push(self, option, value):
+        formatted_option = self._format_option(option)
+        self.args.append(formatted_option)
+        if value is not self.TO_ENABLE_FLAG:
+            self.args.append(value)
 
     def _format_option(self, option):
         if len(option) == 1:
@@ -48,6 +53,8 @@ class _PipArgumentGenerator(object):
             fmt_str = '--{option}'
         formatted_option = fmt_str.format(option=option)
         return formatted_option
+
+    
 
 
 

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -1,0 +1,65 @@
+"""
+"""
+import pip
+
+DEFAULT_COMMAND = 'install'
+DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
+
+class _PipArgumentGenerator(object):
+
+    DEFAULT_ARGUMENTS = [DEFAULT_COMMAND, '-r', DEFAULT_REQUIREMENTS_FILE]
+    
+    def generate_from(self, config):
+        if not config:
+            return self.DEFAULT_ARGUMENTS
+        self.config = config
+        return self._process_config()
+
+
+    def _process_config(self):
+        self.command = self.config.get('command')
+        self.package = self.config.get('package')
+        if self._installing_single_package():
+            return [DEFAULT_COMMAND, self.package]
+        else:
+            self.generated_args = []
+            self.generated_args.append(self.command)
+            self._process_options()
+            return self.generated_args
+
+    def _installing_single_package(self):
+        return self.command == DEFAULT_COMMAND and self.package
+
+
+    def _process_options(self):
+        self.options = self.config.get('options')
+        for option, value in self.options.iteritems():
+            formatted_option = self._format_option(option)
+            if value:
+                self.generated_args.append(formatted_option)
+                if value is not True:
+                    self.generated_args.append(value)
+
+
+    def _format_option(self, option):
+        if len(option) == 1:
+            fmt_str = '-{option}'
+        else:
+            fmt_str = '--{option}'
+        formatted_option = fmt_str.format(option=option)
+        return formatted_option
+
+
+
+def execute_pip(**kwargs):
+    config = kwargs.get('config')
+    generator = _PipArgumentGenerator()
+    args = generator.generate_from(config)
+    pip.main(args)
+
+
+
+
+def register_tasks(registry):
+    registry.register_task('pip', execute_pip)
+    

--- a/boltfile.py
+++ b/boltfile.py
@@ -3,15 +3,8 @@ import logging
 import bolt
 
 config = {
-    'delete-pyc': {
-        'sourcedir': './',
-        'recursive': True
-    }
+    
 }
 
 
-def hello_tasks(config):
-    print 'Hello Bolt!!!'
-
-
-bolt.register_task('default', hello_tasks)
+bolt.register_task('default', ['pip'])

--- a/test.pyproj
+++ b/test.pyproj
@@ -27,6 +27,9 @@
     <Compile Include="test_btrunner.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="test_tasks\test_bolt_pip.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="test_tasks\test_delete_files.py">
       <SubType>Code</SubType>
     </Compile>

--- a/test/test_tasks/test_bolt_pip.py
+++ b/test/test_tasks/test_bolt_pip.py
@@ -1,0 +1,83 @@
+"""
+"""
+import unittest
+
+import bolt.tasks.bolt_pip as bpip
+
+class TestPipArgumentGenerator(unittest.TestCase):
+
+    def setUp(self):
+        self.subject = bpip._PipArgumentGenerator()
+        return super(TestPipArgumentGenerator, self).setUp()
+    
+    def test_empty_configuration_assumes_a_requirements_file_in_current_directory(self):
+        self.given({})
+        self.expect([bpip.DEFAULT_COMMAND, '-r', bpip.DEFAULT_REQUIREMENTS_FILE])
+
+
+    def test_can_install_single_package(self):
+        config = {
+            'command': 'install',
+            'package': 'apackage'
+        }
+        self.given(config)
+        self.expect(['install', 'apackage'])
+
+
+    def test_options_are_passed_to_command(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'requirement': 'a_requirements_file.txt'
+            }
+        }
+        self.given(config)
+        self.expect(['install', '--requirement', 'a_requirements_file.txt'])
+
+
+    def test_options_can_be_specified_in_their_short_form(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'r': 'a_requirements_file.txt'
+            }
+        }
+        self.given(config)
+        self.expect(['install', '-r', 'a_requirements_file.txt'])
+
+
+    def test_if_value_is_boolean_options_is_specified_as_flag(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'requirement': 'a_requirements_file.txt',
+                'force-reinstall': True
+            }
+        }
+        self.given(config)
+        self.expect(['install', '--requirement', 'a_requirements_file.txt', '--force-reinstall'])
+
+
+    def test_flag_is_not_added_if_false(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'requirement': 'a_requirements_file.txt',
+                'force-reinstall': False
+            }
+        }
+        self.given(config)
+        self.expect(['install', '--requirement', 'a_requirements_file.txt'])
+
+    def given(self, config):
+        self.generated_args = self.subject.generate_from(config)
+
+
+    def expect(self, expected):
+        self.assertListEqual(self.generated_args, expected)
+
+
+
+
+if __name__=='__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
This change implements a task that integrates `pip` with bolt. Users can setup a task that executes `pip` to install the required packages or any other supported commands. The configuration for the task supports a `command` parameter that indicates the `pip` command to execute. If the command being executed is `install`, the configuration supports a `package` parameter with a value of the package to be installed.

```python
config = {
    'pip': {
        'command': 'install',
        'package': 'bolt'
    }
}
```

All other commands, including `install`, support a `options` parameter, which must be set a dictionary where the keys are `pip` supported arguments to the command without leading dashes `--`, and the values are the command line values to specify. Flags can be set to the Boolean value of `True`. Setting a flag value to `False` removes the parameter, so it has not effect, but it comes handy to temporarily disable a flag. Short form of arguments as in `-r` instead of `--requirement` are supported if specified without the leading dash `-`.

```python
config = {
    'pip': {
        'command': 'install',
        'options': {
            'requirement': 'a_requirements.txt',
            'force-install': True,
            'b': './build'
        }
    }
}
```

##### Issue Fixes or Implemented Stories
Implements story #12 

### Testing Performed
Unit tests for the implemented functionality have been added. Additionally, I modified the `boltfile.py` to execute this task and run it, and it worked as advertised.

### Known Issues
There are no known issues.

