### PR TITLE
Implements a task to automate setup.py functionality.

### DIFF
--- a/bolt.pyproj
+++ b/bolt.pyproj
@@ -27,10 +27,16 @@
     <Compile Include="tasks\bolt_pip.py">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="tasks\delete_files.py">
+    <Compile Include="tasks\bolt_delete_files.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="tasks\bolt_setup.py">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="tasks\__init__.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="utils\_utconfig.py">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="utils\_utfiles.py">

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -15,11 +15,13 @@ from bolt._btutils import load_script
 
 # Standard task modules.
 import bolt.tasks.bolt_pip as bolt_pip
-import bolt.tasks.delete_files as delete_files
+import bolt.tasks.bolt_delete_files as bolt_delete_files
+import bolt.tasks.bolt_setup as bolt_setup
 
 def _register_standard_modules(registry):
+    bolt_delete_files.register_tasks(registry)
     bolt_pip.register_tasks(registry)
-    delete_files.register_tasks(registry)
+    bolt_setup.register_tasks(registry)
 
 
 class _BoltApplication(object):

--- a/bolt/about.py
+++ b/bolt/about.py
@@ -2,6 +2,9 @@
 
 """
 project = u'bolt'
+description = """
+A task runner written in Python
+"""
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'
 version = u'0.1'

--- a/bolt/tasks/bolt_delete_files.py
+++ b/bolt/tasks/bolt_delete_files.py
@@ -4,7 +4,7 @@ import glob
 import os
 
 import bolt
-import bolt.utils as ut
+import bolt.utils as utilities
 
 class DeleteFilesTask(object):
 
@@ -26,9 +26,9 @@ class DeleteFilesTask(object):
 
 
     def _execute_delete(self):
-        finder = ut.FileFinder(self.sourcedir, self.pattern, self.recursive)
+        finder = utilities.FileFinder(self.sourcedir, self.pattern, self.recursive)
         matches = finder.find()
-        ut.delete_files_in(matches)
+        utilities.delete_files_in(matches)
 
 
 

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -1,21 +1,17 @@
 """
 """
 import pip
+import bolt.utils as utilities
 
 DEFAULT_COMMAND = 'install'
 DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
+DEFAULT_ARGUMENTS = [DEFAULT_COMMAND, '-r', DEFAULT_REQUIREMENTS_FILE]
 
-class _PipArgumentGenerator(object):
+class _PipArgumentGenerator(utilities.CommonCommandAndArgumentsGenerator):
 
-    DEFAULT_ARGUMENTS = [DEFAULT_COMMAND, '-r', DEFAULT_REQUIREMENTS_FILE]
-    TO_ENABLE_FLAG = True
-    TO_DISABLE_FLAG = False
-    
-    def generate_from(self, config):
-        if not config:
-            return self.DEFAULT_ARGUMENTS
-        self.config = config
-        return self._convert_config_to_arguments()
+
+    def __init__(self):
+        return super(_PipArgumentGenerator, self).__init__(DEFAULT_ARGUMENTS)
 
 
     def _convert_config_to_arguments(self):
@@ -27,33 +23,6 @@ class _PipArgumentGenerator(object):
     @property
     def _installing_single_package(self):
         return self.command == DEFAULT_COMMAND and self.package
-
-    @property
-    def _converted_options(self):
-        self.args = [self.command]
-        self.options = self.config.get('options')
-        {self._push_as_arguments(option, value) for option, value in self.options.items()}       
-        return self.args
-
-    def _push_as_arguments(self, option, value):
-        if value is not self.TO_DISABLE_FLAG:
-            self._do_push(option, value)        
-
-
-    def _do_push(self, option, value):
-        formatted_option = self._format_option(option)
-        self.args.append(formatted_option)
-        if value is not self.TO_ENABLE_FLAG:
-            self.args.append(value)
-
-    def _format_option(self, option):
-        if len(option) == 1:
-            fmt_str = '-{option}'
-        else:
-            fmt_str = '--{option}'
-        formatted_option = fmt_str.format(option=option)
-        return formatted_option
-
     
 
 

--- a/bolt/tasks/bolt_setup.py
+++ b/bolt/tasks/bolt_setup.py
@@ -1,0 +1,30 @@
+"""
+"""
+import distutils.core as dcore
+
+import bolt.utils as utilities
+
+DEFAULT_ARGUMENTS = ['build']
+DEFAULT_SETUP_SCRIPT = 'setup.py'
+
+class _SetupArgumentGenerator(utilities.CommonCommandAndArgumentsGenerator):
+
+    def __init__(self):
+        return super(_SetupArgumentGenerator, self).__init__(DEFAULT_ARGUMENTS)
+
+
+
+def execute_setup(**kwargs):
+    config = kwargs.get('config')
+    setup_script = config.get('script')
+    if setup_script:
+        config['script'] = False
+    else:
+        setup_script = DEFAULT_SETUP_SCRIPT
+    generator = _SetupArgumentGenerator()
+    args = generator.generate_from(config)
+    dcore.run_setup(setup_script, args)
+
+
+def register_tasks(registry):
+    registry.register_task('setup', execute_setup)

--- a/bolt/utils/__init__.py
+++ b/bolt/utils/__init__.py
@@ -1,3 +1,4 @@
 """
 """
 from ._utfiles import *
+from ._utconfig import *

--- a/bolt/utils/_utconfig.py
+++ b/bolt/utils/_utconfig.py
@@ -1,0 +1,50 @@
+"""
+Classes to help processing configurations.
+"""
+
+TO_ENABLE_FLAG = True
+TO_DISABLE_FLAG = False
+
+class CommonCommandAndArgumentsGenerator(object):
+
+    def __init__(self, default_args):
+        self.default_arguments = default_args
+
+
+    def generate_from(self, config):
+        if not config:
+            return self.default_arguments
+        self.config = config
+        return self._convert_config_to_arguments()
+
+
+    def _convert_config_to_arguments(self):
+        self.command = self.config.get('command')
+        return self._converted_options
+            
+
+    @property
+    def _converted_options(self):
+        self.args = [self.command]
+        self.options = self.config.get('options')
+        {self._push_as_arguments(option, value) for option, value in self.options.items()}       
+        return self.args
+
+    def _push_as_arguments(self, option, value):
+        if value is not TO_DISABLE_FLAG:
+            self._do_push(option, value)        
+
+
+    def _do_push(self, option, value):
+        formatted_option = self._format_option(option)
+        self.args.append(formatted_option)
+        if value is not TO_ENABLE_FLAG:
+            self.args.append(value)
+
+    def _format_option(self, option):
+        if len(option) == 1:
+            fmt_str = '-{option}'
+        else:
+            fmt_str = '--{option}'
+        formatted_option = fmt_str.format(option=option)
+        return formatted_option

--- a/boltfile.py
+++ b/boltfile.py
@@ -3,7 +3,10 @@ import logging
 import bolt
 
 config = {
-    
+    'setup': {
+		'command': 'build',
+		'options': {}
+    }
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 from setuptools import setup
+import bolt.about
 
-name = 'bolt'
-version = '0.0.1'
-description = 	"""
-This is a temporary description.
-"""
-author = 'Isaac Rodriguez'
-author_email = 'isaac_rodriguez@live.com'
+name = bolt.about.project
+version = bolt.about.release
+description = 	bolt.about.description
+author = bolt.about.author
+
 packages = ['bolt']
 entry_points = {
     'console_scripts': [
@@ -18,6 +17,5 @@ setup(name=name,
       version=version,
       description=description,
       author=author,
-      author_email=author_email,
       packages=packages,
       entry_points=entry_points)

--- a/test.pyproj
+++ b/test.pyproj
@@ -32,7 +32,13 @@
     <Compile Include="test_tasks\test_bolt_pip.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="test_tasks\test_bolt_setup.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="test_tasks\test_delete_files.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="test_utils\test_utconfig.py">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="test_utils\test_utfiles.py">

--- a/test/test_tasks/test_bolt_pip.py
+++ b/test/test_tasks/test_bolt_pip.py
@@ -12,7 +12,7 @@ class TestPipArgumentGenerator(unittest.TestCase):
     
     def test_empty_configuration_assumes_a_requirements_file_in_current_directory(self):
         self.given({})
-        self.expect([bpip.DEFAULT_COMMAND, '-r', bpip.DEFAULT_REQUIREMENTS_FILE])
+        self.expect(bpip.DEFAULT_ARGUMENTS)
 
 
     def test_can_install_single_package(self):
@@ -24,58 +24,12 @@ class TestPipArgumentGenerator(unittest.TestCase):
         self.expect(['install', 'apackage'])
 
 
-    def test_options_are_passed_to_command(self):
-        config = {
-            'command': 'install',
-            'options': {
-                'requirement': 'a_requirements_file.txt'
-            }
-        }
-        self.given(config)
-        self.expect(['install', '--requirement', 'a_requirements_file.txt'])
-
-
-    def test_options_can_be_specified_in_their_short_form(self):
-        config = {
-            'command': 'install',
-            'options': {
-                'r': 'a_requirements_file.txt'
-            }
-        }
-        self.given(config)
-        self.expect(['install', '-r', 'a_requirements_file.txt'])
-
-
-    def test_if_value_is_boolean_options_is_specified_as_flag(self):
-        config = {
-            'command': 'install',
-            'options': {
-                'requirement': 'a_requirements_file.txt',
-                'force-reinstall': True
-            }
-        }
-        self.given(config)
-        self.expect(['install', '--requirement', 'a_requirements_file.txt', '--force-reinstall'])
-
-
-    def test_flag_is_not_added_if_false(self):
-        config = {
-            'command': 'install',
-            'options': {
-                'requirement': 'a_requirements_file.txt',
-                'force-reinstall': False
-            }
-        }
-        self.given(config)
-        self.expect(['install', '--requirement', 'a_requirements_file.txt'])
-
     def given(self, config):
         self.generated_args = self.subject.generate_from(config)
 
 
     def expect(self, expected):
         commonitems = set(self.generated_args).intersection(expected)
-
         self.assertEqual(len(commonitems), len(expected))
 
 

--- a/test/test_tasks/test_bolt_setup.py
+++ b/test/test_tasks/test_bolt_setup.py
@@ -1,0 +1,29 @@
+import unittest
+import bolt.tasks.bolt_setup as bsetup
+
+
+class TestSetupArgumentGenerator(unittest.TestCase):
+
+    def setUp(self):
+        self. subject = bsetup._SetupArgumentGenerator()
+        return super(TestSetupArgumentGenerator, self).setUp()
+
+
+    def test_uses_default_if_empty_configuration(self):
+        self.given({})
+        self.expect(bsetup.DEFAULT_ARGUMENTS)
+
+
+    def given(self, config):
+        self.generated_args = self.subject.generate_from(config)
+
+
+    def expect(self, expected):
+        commonitems = set(self.generated_args).intersection(expected)
+        self.assertEqual(len(commonitems), len(expected))
+
+
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/test/test_tasks/test_delete_files.py
+++ b/test/test_tasks/test_delete_files.py
@@ -1,7 +1,7 @@
 import unittest
 
 import bolt
-import bolt.tasks.delete_files as df
+import bolt.tasks.bolt_delete_files as df
 
 
 class TestDeleteFilesTask(unittest.TestCase):

--- a/test/test_utils/test_utconfig.py
+++ b/test/test_utils/test_utconfig.py
@@ -1,0 +1,89 @@
+import unittest
+
+import bolt.utils._utconfig as utconfig
+
+
+class TestCommonCommandAndArgumentGenerator(unittest.TestCase):
+
+    def setUp(self):
+        self.subject = CommonCommandAndArgumentsGeneratorMock()
+        return super(TestCommonCommandAndArgumentGenerator, self).setUp()
+
+
+    def test_returns_default_arguments_if_empty_configuration(self):
+        self.given({})
+        self.expect(self.subject.DEFAULT_ARGUMENTS)
+
+
+    def test_returns_default_arguments_if_no_configuration(self):
+        self.given(None)
+        self.expect(self.subject.DEFAULT_ARGUMENTS)
+
+
+    def test_options_are_passed_to_command(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'requirement': 'a_requirements_file.txt'
+            }
+        }
+        self.given(config)
+        self.expect(['install', '--requirement', 'a_requirements_file.txt'])
+
+
+    def test_options_can_be_specified_in_their_short_form(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'r': 'a_requirements_file.txt'
+            }
+        }
+        self.given(config)
+        self.expect(['install', '-r', 'a_requirements_file.txt'])
+
+
+    def test_if_value_is_boolean_options_is_specified_as_flag(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'requirement': 'a_requirements_file.txt',
+                'force-reinstall': True
+            }
+        }
+        self.given(config)
+        self.expect(['install', '--requirement', 'a_requirements_file.txt', '--force-reinstall'])
+
+
+    def test_flag_is_not_added_if_false(self):
+        config = {
+            'command': 'install',
+            'options': {
+                'requirement': 'a_requirements_file.txt',
+                'force-reinstall': False
+            }
+        }
+        self.given(config)
+        self.expect(['install', '--requirement', 'a_requirements_file.txt'])
+
+
+    def given(self, config):
+        self.actual = self.subject.generate_from(config)
+
+
+    def expect(self, expected):
+        commonitems = set(self.actual).intersection(expected)
+        self.assertEqual(len(commonitems), len(expected))
+
+
+
+class CommonCommandAndArgumentsGeneratorMock(utconfig.CommonCommandAndArgumentsGenerator):
+
+    DEFAULT_ARGUMENTS = ['a_command', '--switch', 'value']
+
+    def __init__(self):
+        return super(CommonCommandAndArgumentsGeneratorMock, self).__init__(self.DEFAULT_ARGUMENTS)
+
+
+
+if __name__=='__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
This change provides a bolt tasks to automate the functionality of the `setup.py` script. The task supports a configuration that exposes the commands and parameters that can be used with `setup.py` and `distutils`.


##### Issue Fixes or Implemented Stories
Implements #11 

### Testing Performed
Unit tests have been added to test the functionality and manual testing has been performed.
