### PR TITLE
Implemented Task to Execute Shell Command

### DIFF
--- a/bolt.pyproj
+++ b/bolt.pyproj
@@ -33,6 +33,9 @@
     <Compile Include="tasks\bolt_setup.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="tasks\bolt_shell.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="tasks\__init__.py">
       <SubType>Code</SubType>
     </Compile>

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -17,11 +17,13 @@ from bolt._btutils import load_script
 import bolt.tasks.bolt_pip as bolt_pip
 import bolt.tasks.bolt_delete_files as bolt_delete_files
 import bolt.tasks.bolt_setup as bolt_setup
+import bolt.tasks.bolt_shell as bolt_shell
 
 def _register_standard_modules(registry):
     bolt_delete_files.register_tasks(registry)
     bolt_pip.register_tasks(registry)
     bolt_setup.register_tasks(registry)
+    bolt_shell.register_tasks(registry)
 
 
 class _BoltApplication(object):

--- a/bolt/tasks/bolt_shell.py
+++ b/bolt/tasks/bolt_shell.py
@@ -1,0 +1,39 @@
+"""
+"""
+import subprocess as sp
+
+from bolt._bterror import InvalidConfigurationError
+
+
+class ShellExecuteTask(object):
+    
+    def __call__(self, **kwargs):
+        self.config = kwargs.get('config')
+        self._verify_valid_configuration()
+        self._build_command_line()
+        self._run()
+
+
+    def _verify_valid_configuration(self):
+        if not self.config:
+            raise InvalidConfigurationError('A shell command is required')
+        self.command = self.config.get('command')
+        if not self.command:
+            raise InvalidConfigurationError('A command must be specified')
+
+
+    def _build_command_line(self):
+        self.command_line = [self.command]
+        arguments = self.config.get('arguments')
+        if arguments:
+            self.command_line.extend(arguments)
+
+
+    def _run(self):
+        result = sp.call(self.command_line)
+        result.check_returncode()
+        
+
+
+def register_tasks(registry):
+    registry.register_task('shell', ShellExecuteTask())

--- a/boltfile.py
+++ b/boltfile.py
@@ -3,11 +3,11 @@ import logging
 import bolt
 
 config = {
-    'setup': {
-		'command': 'build',
-		'options': {}
+    'shell': {
+		'command': 'conttest',
+		'arguments': ['nosetests', './test/']
     }
 }
 
 
-bolt.register_task('default', ['pip'])
+bolt.register_task('default', ['shell'])

--- a/test.pyproj
+++ b/test.pyproj
@@ -35,6 +35,9 @@
     <Compile Include="test_tasks\test_bolt_setup.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="test_tasks\test_bolt_shell.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="test_tasks\test_delete_files.py">
       <SubType>Code</SubType>
     </Compile>

--- a/test/test_tasks/test_bolt_shell.py
+++ b/test/test_tasks/test_bolt_shell.py
@@ -1,0 +1,81 @@
+import unittest
+
+import bolt.tasks.bolt_shell as bsh
+
+class TestShellExecuteTask(unittest.TestCase):
+
+    def setUp(self):
+        self.subject = ShellExecuteTaskSpy()
+        return super(TestShellExecuteTask, self).setUp()
+
+
+    def test_configuration_cannot_be_empty(self):
+        with self.assertRaises(bsh.InvalidConfigurationError):
+            self.given({})
+
+
+    def test_configuration_must_contain_command(self):
+        with self.assertRaises(bsh.InvalidConfigurationError):
+            config = {
+                'arguments': ['foo']
+            }
+            self.given(config)
+
+
+    def test_command_line_contains_no_arguments_if_none_specified(self):
+        config = {
+            'command': 'ls'
+        }
+        self.given(config)
+        self.expect_command_line(['ls'])
+
+
+    def test_command_line_contains_specified_arguments(self):
+        config = {
+            'command': 'command',
+            'arguments': ['arg1', 'arg2']
+        }
+        self.given(config)
+        self.expect_command_line(['command', 'arg1', 'arg2'])
+
+
+    def test_raises_if_command_fails(self):
+        with self.assertRaises(Exception):
+            config = {
+                'command': 'failed',
+            }
+            self.given(config)
+
+
+
+    def given(self, config):
+        self.result = self.subject(config=config)
+
+
+    def expect_command_line(self, expected):
+        self.assertListEqual(self.subject.args, expected)
+
+
+
+class ShellExecuteTaskSpy(bsh.ShellExecuteTask):
+
+    def __init__(self):
+        self.returncode = 0
+        return super(ShellExecuteTaskSpy, self).__init__()
+
+    def _run(self):
+        self.args = self.command_line 
+        if self.args[0] == 'failed':
+            self.returncode = 1
+        self.check_returncode()
+
+
+    def check_returncode(self):
+        if self.returncode != 0:
+            raise Exception('Failed command')
+
+
+
+
+if __name__=='__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
This task allows to launch any command line process by specifying the command and arguments to be used. The task checks the return code of the command and fails if the return code is not 0.


##### Issue Fixes or Implemented Stories
Add issue numbers 

### Notes to Integrators
The task uses the `subprocess` module in Python to launch the command. This module has been recently extended in Python 3.5 to add a `run()` function, which doesn't work in earlier version nor 2.x. The current implementation uses the `call()` method which in the context used seems to be doing the same job.


### Testing Performed
Unit tests for the new code has been added. The task has been used to run all the automation and verify it works.
