### PR TITLE
Fixes accessing subtasks

### DIFF
--- a/bolt/_btregistry.py
+++ b/bolt/_btregistry.py
@@ -28,7 +28,8 @@ class TaskRegistry(object):
         :param name:
         :return:
         """
-        return  self._tasks[name]
+        task_name = self._extract_task_name(name)
+        return  self._tasks[task_name]
 
 
     def _is_valid_task(self, task):
@@ -38,5 +39,9 @@ class TaskRegistry(object):
                 if not isinstance(t, str):
                     return False
         return callable(task) or is_list
+
+
+    def _extract_task_name(self, full_task):
+        return full_task.split('.')[0]
 
 

--- a/bolt/about.py
+++ b/bolt/about.py
@@ -8,4 +8,4 @@ A task runner written in Python
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'
 version = u'0.1'
-release = u'0.1.4'
+release = u'0.1.0-alpha01'

--- a/test/test_btregistry.py
+++ b/test/test_btregistry.py
@@ -35,6 +35,15 @@ class TestTaskRegistry(unittest.TestCase):
             self.subject.register_task("invalid", ['foo', 'bar', 3])
 
 
+    def test_allows_specifying_subtask_returing_correct_callable(self):
+        task_name = 'test'
+        subtask_name = 'test.sub'
+        self.subject.register_task(task_name, self.test_callable)
+        actual = self.subject.get(subtask_name)
+
+        self.assertEqual(actual, self.test_callable)
+
+
 
     def test_callable(self):
         pass


### PR DESCRIPTION
### Description
This submission fixes the implementation of `TaskRegistry` to allow retrieving subtasks in the form `task.subtask`. 
