### PR TITLE
Fixes handling of return values for shell task

### DIFF
--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -45,6 +45,7 @@ class _BoltApplication(object):
     def run(self):
         self._initialize_execution_options()
         self._initialize_logging()
+        logging.info("Current working directory: " + os.getcwd())
         self._register_standard_modules()
         self._load_bolt_file()
         self._initialize_configuration_manager()
@@ -141,6 +142,7 @@ def run():
     Entry point for the `bolt` executable.
     """
     try:
+        print(os.getcwd())
         _bolt_application.run()
     except Exception as e:
         logging.exception(e)

--- a/bolt/tasks/bolt_shell.py
+++ b/bolt/tasks/bolt_shell.py
@@ -57,7 +57,10 @@ class ShellExecuteTask(object):
 
     def _run(self):
         result = sp.call(self.command_line)
-        result.check_returncode()
+        if isinstance(result, sp.CompletedProcess):
+            result.check_returncode()
+        else:
+            assert result == 0
         
 
 


### PR DESCRIPTION
### Description
`subprocess.call()` returns the status code of the running process, but some times it returns an instance of `subprocess.CompletedProcess`. I added a check to handle it correctly.
