### PR TITLE
Fixes return code handling on shell process execution

### DIFF
--- a/bolt/tasks/bolt_shell.py
+++ b/bolt/tasks/bolt_shell.py
@@ -56,11 +56,7 @@ class ShellExecuteTask(object):
 
 
     def _run(self):
-        result = sp.call(self.command_line)
-        if isinstance(result, sp.CompletedProcess):
-            result.check_returncode()
-        else:
-            assert result == 0
+        sp.check_call(self.command_line)
         
 
 


### PR DESCRIPTION
### Description
At some point, the return of code from calling `subprocess.call()` got broken in `ShellExecuteTask` between Python 2.7.x and Python 3.x. There has been some API changes in Python 3.5 that will cause this to break, but I added, what I thought, it was a fix. Turns out it wasn't. The code worked for Python 3.5 and later but broke Python 2.7.x.

What I was trying to do is pretty much what `subprocess.check_call()` does, so I replaced the method we are calling and hopefully it will give us consistent behavior between all versions of Python.

### Testing Performed
I run all the unit tests and they pass. Of course, the code I changed doesn't really get exercise by the unit tests.
