### PR TITLE
Integrated Task for ContTest

### DIFF
--- a/bolt.pyproj
+++ b/bolt.pyproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="about.py" />
+    <Compile Include="tasks\bolt_conttest.py" />
     <Compile Include="tasks\bolt_pip.py">
       <SubType>Code</SubType>
     </Compile>

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -18,12 +18,14 @@ import bolt.tasks.bolt_pip as bolt_pip
 import bolt.tasks.bolt_delete_files as bolt_delete_files
 import bolt.tasks.bolt_setup as bolt_setup
 import bolt.tasks.bolt_shell as bolt_shell
+import bolt.tasks.bolt_conttest as bolt_conttest
 
 def _register_standard_modules(registry):
     bolt_delete_files.register_tasks(registry)
     bolt_pip.register_tasks(registry)
     bolt_setup.register_tasks(registry)
     bolt_shell.register_tasks(registry)
+    bolt_conttest.register_tasks(registry)
 
 
 class _BoltApplication(object):
@@ -137,12 +139,15 @@ def register_task(name, task):
     _bolt_application.registry.register_task(name, task)
 
 
+def run_task(task_name):
+    _bolt_application.run_task(task_name)
+
+
 def run():
     """
     Entry point for the `bolt` executable.
     """
     try:
-        print(os.getcwd())
         _bolt_application.run()
     except Exception as e:
         logging.exception(e)

--- a/bolt/tasks/bolt_conttest.py
+++ b/bolt/tasks/bolt_conttest.py
@@ -1,0 +1,38 @@
+"""
+conttest
+--------
+
+This task uses ``conttest`` to monitor a directory for changes and executes the specified
+task everytime a change is made. The following configuration is supported::
+
+    config = {
+        'conttest': {
+            'task': 'registered_task',
+            'directory': './directory/to/monitor/'
+        }
+    }
+
+The ``task`` parameter is the task to be executed and must be registered in ``boltfile.py``.
+The ``directory`` parameter is the directory (including sub-directories) to monitor for 
+changes.
+
+To use this task, you need to have ``conttest`` installed, which you can do by calling::
+
+    pip install conttest
+"""
+import conttest.conttest as ct
+import bolt 
+
+
+
+
+def execute_conttest(**kwargs):
+    config = kwargs.get('config')
+    task_name = config.get('task')
+    directory = config.get('directory') or './'
+    ct.watch_dir(directory, lambda: bolt.run_task(task_name), method=ct.TIMES)
+
+
+
+def register_tasks(registry):
+    registry.register_task('conttest', execute_conttest)

--- a/boltfile.py
+++ b/boltfile.py
@@ -3,11 +3,19 @@ import logging
 import bolt
 
 config = {
+    'delete-pyc': {
+        'sourcedir': './',
+        'recursive': True
+    },
     'shell': {
-		'command': 'conttest',
-		'arguments': ['nosetests', './test/']
+		'command': 'nosetests',
+		'arguments': ['./test/']
+    },
+    'conttest' : {
+        'task': 'ut'
     }
 }
 
-bolt.register_task('ct', ['shell'])
+bolt.register_task('ut', ['delete-pyc', 'shell'])
+bolt.register_task('ct', ['conttest'])
 bolt.register_task('default', ['shell'])

--- a/docs/source/ug/provided_tasks.rst
+++ b/docs/source/ug/provided_tasks.rst
@@ -23,3 +23,7 @@ The following documents the included tasks and how they work.
 
 ..  automodule:: bolt.tasks.bolt_shell
     :members:
+
+
+..  automodule:: bolt.tasks.bolt_conttest
+    :members:


### PR DESCRIPTION
This submission adds a new task that uses `conttest` to monitor the file system and execute another specified task when changes are detected. 

Implements issue #10