### PR TITLE
Delay Load Conttest

### DIFF
--- a/bolt/about.py
+++ b/bolt/about.py
@@ -8,4 +8,4 @@ A task runner written in Python
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'
 version = u'0.1'
-release = u'0.1.0-alpha03'
+release = u'0.1.0-alpha04'

--- a/bolt/tasks/bolt_conttest.py
+++ b/bolt/tasks/bolt_conttest.py
@@ -21,13 +21,13 @@ To use this task, you need to have ``conttest`` installed, which you can do by c
     pip install conttest
 """
 import logging
-import conttest.conttest as ct
 import bolt 
 
 
 
 
 def execute_conttest(**kwargs):
+    import conttest.conttest as ct
     config = kwargs.get('config')
     task_name = config.get('task')
     directory = config.get('directory') or './'


### PR DESCRIPTION
### Description
This submission changes the time when `conttest` is loaded to when the task is executed. Previously, the module was loaded at the beginning of the task implementation module, which it cause it to be loaded during setup, which some times `conttest` is not available. This should be done with every task module that relies in some non-standard module.

