### PR TITLE
Fixes running nose under conttest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ var/
 .idea/
 # Visual Studio
 .vs/
+.vscode/
 
 # Local virtual environments
 .virtualenv/

--- a/bolt/tasks/bolt_nose.py
+++ b/bolt/tasks/bolt_nose.py
@@ -2,6 +2,7 @@
 """
 import logging
 import os.path
+import subprocess as sp
 
 import bolt.utils as utilities
 
@@ -17,7 +18,7 @@ class _NoseArgumentGenerator(utilities.ArgumentsGenerator):
 
 
     def _convert_config_to_arguments(self):
-        self.args.append('dummy')
+        self.args.append('nosetests')
         super(_NoseArgumentGenerator, self)._convert_config_to_arguments()
         directory = self.config.get('directory') or DEFAULT_DIR
         directory = os.path.abspath(directory)
@@ -29,16 +30,20 @@ class _NoseArgumentGenerator(utilities.ArgumentsGenerator):
 
 def execute_nose(**kwargs):
     logging.info('Executing nose')
-    import nose.core
     config = kwargs.get('config')
     generator = _NoseArgumentGenerator()
     args = generator.generate_from(config)
     logging.debug('Arguments: ' + repr(args))
-    try:
-        nose.core.main(argv=args)
-    except SystemExit as ex:
-        # Nose tries to sys.exit(), so we have to intercept it.
-        pass
+    result = sp.call(args)
+    # try:
+    #     test_program = nose.core.TestProgram(argv=args, exit=False) 
+    #     result = test_program.success
+    #     del(test_program)
+
+    #     # nose.core.run(argv=args)
+    # except SystemExit as ex:
+    #     # Nose tries to sys.exit(), so we have to intercept it.
+    #     pass
 
 
 

--- a/test/test_btrunner.py
+++ b/test/test_btrunner.py
@@ -71,6 +71,11 @@ class TestTaskRunner(unittest.TestCase):
             self.subject.build('inexistent')
 
 
+    # def test_exits_if_task_does_not_return_zero(self):
+    #     with self.assertRaises(SystemExit):
+    #         self.given('failing_task')
+
+
     def given(self, task_name):
         self.subject.build(task_name)
         self.subject.run()

--- a/test/test_tasks/test_bolt_nose.py
+++ b/test/test_tasks/test_bolt_nose.py
@@ -73,9 +73,7 @@ class TestNoseArgumentGenerator(unittest.TestCase):
         self.generated_args = self.subject.generate_from(config)
 
 
-    def expect(self, expected):
-        if expected:
-            expected.insert(0, 'dummy')
+    def expect(self, expected):        
         commonitems = set(self.generated_args).intersection(expected)
         self.assertEqual(len(commonitems), len(expected))
 


### PR DESCRIPTION
### Description
Loading `nose.core` was caching the set of tests to run, so when new tests were added, they were not being executed from run to run using `conttest`. This happened just by loading `nose.core`, so I changed the invocation to use `subprocess` as command-line parameter. 

