### PR TITLE
Improved Error Handling of Tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ var/
 .idea/
 # Visual Studio
 .vs/
+.vscode/
 
 # Local virtual environments
 .virtualenv/

--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -56,8 +56,8 @@ class _BoltApplication(object):
         self._run_main_task()
 
 
-    def run_task(self, task_name):
-        runner = TaskRunner(self.config_manager, self.registry)
+    def run_task(self, task_name, continue_on_error):
+        runner = TaskRunner(self.config_manager, self.registry, continue_on_error)
         runner.build(task_name)
         runner.run()
 
@@ -109,6 +109,7 @@ class _BoltApplication(object):
         parser.add_argument('--bolt-file', default='boltfile.py')
         parser.add_argument('--log-level', default='info')
         parser.add_argument('--log-file', default=None)
+        parser.add_argument('--continue-on-error', default=False)
         return parser
 
 
@@ -123,7 +124,7 @@ class _BoltApplication(object):
 
 
     def _run_main_task(self):
-        self.run_task(self._options.task)
+        self.run_task(self._options.task, self._options.continue_on_error)
 
 
 _bolt_application = _BoltApplication()
@@ -141,8 +142,9 @@ def register_task(name, task):
     _bolt_application.registry.register_task(name, task)
 
 
-def run_task(task_name):
-    _bolt_application.run_task(task_name)
+def run_task(task_name, continue_on_error=None):
+    continue_on_error = continue_on_error or False
+    _bolt_application.run_task(task_name, continue_on_error)
 
 
 def run():

--- a/bolt/_btrunner.py
+++ b/bolt/_btrunner.py
@@ -5,9 +5,10 @@ class TaskRunner(object):
     """
     """
 
-    def __init__(self, config, registry):
+    def __init__(self, config, registry, continue_on_error):
         self._config = config
         self._registry = registry
+        self._continue_on_error = continue_on_error
         self._script = None
 
 
@@ -19,7 +20,8 @@ class TaskRunner(object):
     def run(self):
         for task in self._script:
             operation, config = task
-            operation(config=config)
+            result = operation(config=config)
+            self._check_result(result)
 
 
     def _build_task(self, task_name):
@@ -31,3 +33,8 @@ class TaskRunner(object):
         else:
             for subtask in task_operation:
                 self._build_task(subtask)
+
+
+    def _check_result(self, result):
+        if result not in {0, None} and not self._continue_on_error:
+            raise SystemExit(result or 1)

--- a/bolt/about.py
+++ b/bolt/about.py
@@ -8,4 +8,4 @@ A task runner written in Python
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'
 version = u'0.1'
-release = u'0.1.0-alpha04'
+release = u'0.1.0a4'

--- a/bolt/tasks/bolt_conttest.py
+++ b/bolt/tasks/bolt_conttest.py
@@ -32,7 +32,8 @@ def execute_conttest(**kwargs):
     task_name = config.get('task')
     directory = config.get('directory') or './'
     logging.info('Executing continously "{task}" at {directory}'.format(task=task_name, directory=directory))
-    ct.watch_dir(directory, lambda: bolt.run_task(task_name), method=ct.TIMES)
+    continue_on_error = True
+    ct.watch_dir(directory, lambda: bolt.run_task(task_name, continue_on_error), method=ct.TIMES)
 
 
 

--- a/bolt/tasks/bolt_delete_files.py
+++ b/bolt/tasks/bolt_delete_files.py
@@ -65,6 +65,7 @@ class DeleteFilesTask(object):
     def __call__(self, **kwargs):
         self._set_valid_configuration(kwargs.get('config'))
         self._execute_delete()
+        return 0
 
 
     def _set_valid_configuration(self, config):

--- a/bolt/tasks/bolt_nose.py
+++ b/bolt/tasks/bolt_nose.py
@@ -2,6 +2,7 @@
 """
 import logging
 import os.path
+import subprocess as sp
 
 import bolt.utils as utilities
 
@@ -17,7 +18,7 @@ class _NoseArgumentGenerator(utilities.ArgumentsGenerator):
 
 
     def _convert_config_to_arguments(self):
-        self.args.append('dummy')
+        self.args.append('nosetests')
         super(_NoseArgumentGenerator, self)._convert_config_to_arguments()
         directory = self.config.get('directory') or DEFAULT_DIR
         directory = os.path.abspath(directory)
@@ -29,16 +30,20 @@ class _NoseArgumentGenerator(utilities.ArgumentsGenerator):
 
 def execute_nose(**kwargs):
     logging.info('Executing nose')
-    import nose.core
     config = kwargs.get('config')
     generator = _NoseArgumentGenerator()
     args = generator.generate_from(config)
     logging.debug('Arguments: ' + repr(args))
-    try:
-        nose.core.main(argv=args)
-    except SystemExit as ex:
-        # Nose tries to sys.exit(), so we have to intercept it.
-        pass
+    result = sp.call(args)
+    # try:
+    #     test_program = nose.core.TestProgram(argv=args, exit=False) 
+    #     result = test_program.success
+    #     del(test_program)
+
+    #     # nose.core.run(argv=args)
+    # except SystemExit as ex:
+    #     # Nose tries to sys.exit(), so we have to intercept it.
+    #     pass
 
 
 

--- a/bolt/tasks/bolt_nose.py
+++ b/bolt/tasks/bolt_nose.py
@@ -35,15 +35,7 @@ def execute_nose(**kwargs):
     args = generator.generate_from(config)
     logging.debug('Arguments: ' + repr(args))
     result = sp.call(args)
-    # try:
-    #     test_program = nose.core.TestProgram(argv=args, exit=False) 
-    #     result = test_program.success
-    #     del(test_program)
-
-    #     # nose.core.run(argv=args)
-    # except SystemExit as ex:
-    #     # Nose tries to sys.exit(), so we have to intercept it.
-    #     pass
+    return result
 
 
 

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -74,7 +74,11 @@ def execute_pip(**kwargs):
     generator = _PipArgumentGenerator()
     args = generator.generate_from(config)
     logging.debug('Arguments: ' + repr(args))
-    pip.main(args)
+    try:
+        pip.main(args)
+    except SystemExit as exc:
+        return exc.code
+    return 0
 
 
 

--- a/bolt/tasks/bolt_setup.py
+++ b/bolt/tasks/bolt_setup.py
@@ -47,6 +47,7 @@ def execute_setup(**kwargs):
     generator = _SetupArgumentGenerator()
     args = generator.generate_from(config)
     dcore.run_setup(setup_script, args)
+    return 0
 
 
 def register_tasks(registry):

--- a/bolt/tasks/bolt_shell.py
+++ b/bolt/tasks/bolt_shell.py
@@ -38,7 +38,7 @@ class ShellExecuteTask(object):
         self.config = kwargs.get('config')
         self._verify_valid_configuration()
         self._build_command_line()
-        self._run()
+        return self._run()
 
 
     def _verify_valid_configuration(self):
@@ -58,7 +58,7 @@ class ShellExecuteTask(object):
 
     def _run(self):
         logging.debug('Shell command line: ', repr(self.command_line))
-        sp.check_call(self.command_line)
+        return sp.call(self.command_line)
         
 
 

--- a/test/test_btrunner.py
+++ b/test/test_btrunner.py
@@ -11,7 +11,7 @@ class TestTaskRunner(unittest.TestCase):
     def setUp(self):
         self.setUpRegistry()
         self.setUpConfig()
-        self.subject = runner.TaskRunner(self.config_mgr, self.registry)
+        self.subject = runner.TaskRunner(self.config_mgr, self.registry, False)
         self.executed_tasks = []
         return super(TestTaskRunner, self).setUp()
 
@@ -23,6 +23,8 @@ class TestTaskRunner(unittest.TestCase):
         self.registry.register_task('invalid', self.invalid_task)
         self.registry.register_task('multi_task', ['task_1', 'task_2'])
         self.registry.register_task('configurable', self.configurable_task)
+        self.registry.register_task('failing_task', self.failing_task)
+        self.registry.register_task('multi_task_with_failures', ['task_1', 'failing_task', 'task_2'])
 
 
     def setUpConfig(self):
@@ -62,7 +64,7 @@ class TestTaskRunner(unittest.TestCase):
 
     def test_build_is_enforced_before_run(self):
         with self.assertRaises(Exception):
-            subject = runner.TaskRunner(self.config_mgr, self.registry)
+            subject = runner.TaskRunner(self.config_mgr, self.registry, False)
             subject.run()
 
 
@@ -71,9 +73,16 @@ class TestTaskRunner(unittest.TestCase):
             self.subject.build('inexistent')
 
 
-    # def test_exits_if_task_does_not_return_zero(self):
-    #     with self.assertRaises(SystemExit):
-    #         self.given('failing_task')
+    def test_exits_if_task_does_not_return_zero(self):
+        with self.assertRaises(SystemExit):
+            self.given('failing_task')
+
+
+    def test_continues_on_error_if_specified(self):
+        continue_on_error = True
+        self.subject = runner.TaskRunner(self.config_mgr, self.registry, continue_on_error)
+        self.given('multi_task_with_failures')
+        self.expect_executed('task_2')
 
 
     def given(self, task_name):
@@ -87,21 +96,28 @@ class TestTaskRunner(unittest.TestCase):
 
     def task_1_callback(self, config):
         self.executed_tasks.append('task_1')
+        return 0
 
 
     def task_2_callback(self, **kwargs):
         config = kwargs.get('config')
         self.executed_tasks.append('task_2')
+        return 0
 
 
     def invalid_task(self, noconfig):
-        pass
+        return 0
 
 
     def configurable_task(self, config):
         param = config.get('param')
         self.assertEqual(param, 'value')
         self.executed_tasks.append('configurable')
+        return 0
+
+
+    def failing_task(self, config):
+        return 1
 
 
 

--- a/test/test_btrunner.py
+++ b/test/test_btrunner.py
@@ -71,6 +71,11 @@ class TestTaskRunner(unittest.TestCase):
             self.subject.build('inexistent')
 
 
+    # def test_exits_if_task_does_not_return_zero(self):
+    #     with self.assertRaises(SystemExit):
+    #         self.given('failing_task')
+
+
     def given(self, task_name):
         self.subject.build(task_name)
         self.subject.run()

--- a/test/test_tasks/test_bolt_nose.py
+++ b/test/test_tasks/test_bolt_nose.py
@@ -73,9 +73,7 @@ class TestNoseArgumentGenerator(unittest.TestCase):
         self.generated_args = self.subject.generate_from(config)
 
 
-    def expect(self, expected):
-        if expected:
-            expected.insert(0, 'dummy')
+    def expect(self, expected):        
         commonitems = set(self.generated_args).intersection(expected)
         self.assertEqual(len(commonitems), len(expected))
 


### PR DESCRIPTION
### Description
A new switch `--continue-on-error` is now supported that allows bolt to continue executing tasks if they report failures. This allow us to let task implementers to handle all exceptions and return an error code that it is evaluated and if the value is not 0, we continue or exit according to the switch. The switch by default is set to false, so the task will abort.