### PR TITLE
Provides a task to create directories

### DIFF
--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -20,6 +20,7 @@ import bolt.tasks.bolt_setup as bolt_setup
 import bolt.tasks.bolt_shell as bolt_shell
 import bolt.tasks.bolt_conttest as bolt_conttest
 import bolt.tasks.bolt_nose as bolt_nose
+import bolt.tasks.bolt_mkdir as bolt_mkdir 
 
 def _register_standard_modules(registry):
     bolt_delete_files.register_tasks(registry)
@@ -28,6 +29,7 @@ def _register_standard_modules(registry):
     bolt_shell.register_tasks(registry)
     bolt_conttest.register_tasks(registry)
     bolt_nose.register_tasks(registry)
+    bolt_mkdir.register_tasks(registry)
 
 
 class _BoltApplication(object):

--- a/bolt/tasks/bolt_mkdir.py
+++ b/bolt/tasks/bolt_mkdir.py
@@ -1,0 +1,28 @@
+"""
+mkdir
+-----
+
+Creates the directory specified, including intermediate directories, if they
+do not exist::
+
+    config = {
+        'mkdir': {
+            'directory': 'several/intermediate/directories'
+        }
+    }
+"""
+import logging
+import os
+
+
+def execute_mkdir(**kwargs):
+    config = kwargs.get('config')
+    directory = config.get('directory')
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+
+def register_tasks(registry):
+    registry.register_task('mkdir', execute_mkdir)
+    logging.debug('mkdir task registered.')
+    

--- a/bolt/tasks/bolt_nose.py
+++ b/bolt/tasks/bolt_nose.py
@@ -1,4 +1,21 @@
 """
+nose
+----
+
+Executes unit tests using nose and nosetests as the unit test runner. The task
+allows to specify the directory where the tests are located through the ``directory``
+parameter and supports all the arguments available in the installed version 
+of nosetests::
+
+    config = {
+        'directory': 'test/unit',
+        'xunit-file': 'output/unit_tests.xml'
+        'with-coverage': True,
+        'cover-erase': True,
+        'cover-package': 'mypackage',
+        'cover-html': True,
+        'cover-html-dir': 'output/coverage',
+    }
 """
 import logging
 import os.path

--- a/boltfile.py
+++ b/boltfile.py
@@ -26,6 +26,9 @@ config = {
     'conttest' : {
         'task': 'ut'
     },
+    'mkdir': {
+        'directory': _output_dir,
+    },
     'nose': {
         'directory': _test_dir,
         'ci': {
@@ -55,7 +58,7 @@ bolt.register_task('ct', ['conttest'])
 bolt.register_task('pack', ['setup', 'setup.egg-info'])
 
 # CI/CD tasks
-bolt.register_task('run-unit-tests', ['nose.ci'])
+bolt.register_task('run-unit-tests', ['mkdir', 'nose.ci'])
 
 # Default task (not final).
 bolt.register_task('default', ['pip', 'ut'])

--- a/docs/source/ug/provided_tasks.rst
+++ b/docs/source/ug/provided_tasks.rst
@@ -13,6 +13,14 @@ The following documents the included tasks and how they work.
     :members:
 
 
+..  automodule:: bolt.tasks.bolt_mkdir
+    :members:
+
+
+..  automodule:: bolt.tasks.bolt_shell
+    :members:
+
+
 ..  automodule:: bolt.tasks.bolt_pip
     :members:
 
@@ -21,9 +29,9 @@ The following documents the included tasks and how they work.
     :members:
 
 
-..  automodule:: bolt.tasks.bolt_shell
+..  automodule:: bolt.tasks.bolt_nose
     :members:
 
-
+    
 ..  automodule:: bolt.tasks.bolt_conttest
     :members:


### PR DESCRIPTION
### Description
Provides a `mkdir` task that allows to create directories. The submission also includes the documentation for the previously added `nose` task, which was missing.

