### PR TITLE
Conttest Task Coverage

### DIFF
--- a/bolt/tasks/bolt_conttest.py
+++ b/bolt/tasks/bolt_conttest.py
@@ -21,22 +21,28 @@ To use this task, you need to have ``conttest`` installed, which you can do by c
     pip install conttest
 """
 import logging
+import os
+
 import bolt 
 
 
+class ExecuteConttest(object):
+
+    def __call__(self, **kwargs):
+        config = kwargs.get('config') 
+        self.task_name = config.get('task')
+        self.directory = config.get('directory') or os.getcwd()
+        self.continue_on_error = True
+        logging.info('Executing continously "{task}" at {directory}'.format(task=self.task_name, directory=self.directory))
+        self.execute_task()
 
 
-def execute_conttest(**kwargs):
-    import conttest.conttest as ct
-    config = kwargs.get('config')
-    task_name = config.get('task')
-    directory = config.get('directory') or './'
-    logging.info('Executing continously "{task}" at {directory}'.format(task=task_name, directory=directory))
-    continue_on_error = True
-    ct.watch_dir(directory, lambda: bolt.run_task(task_name, continue_on_error), method=ct.TIMES)
+    def execute_task(self):
+        import conttest.conttest as ct
+        ct.watch_dir(self.directory, lambda: bolt.run_task(self.task_name, self.continue_on_error), method=ct.TIMES)
 
 
 
 def register_tasks(registry):
-    registry.register_task('conttest', execute_conttest)
+    registry.register_task('conttest', ExecuteConttest())
     logging.debug('conttest task registered.')

--- a/boltfile.py
+++ b/boltfile.py
@@ -60,7 +60,7 @@ config = {
 
 # Development tasks
 bolt.register_task('clear-pyc', ['delete-pyc', 'delete-pyc.test-pyc'])
-bolt.register_task('ut', ['clear-pyc', 'coverage'])
+bolt.register_task('ut', ['clear-pyc', 'nose'])
 bolt.register_task('ct', ['conttest'])
 bolt.register_task('pack', ['setup', 'setup.egg-info'])
 

--- a/test/test_tasks/_mocks.py
+++ b/test/test_tasks/_mocks.py
@@ -1,0 +1,9 @@
+"""
+"""
+import bolt._btregistry as btr
+
+class TaskRegistryDouble(btr.TaskRegistry):
+    
+    def contains(self, name):
+        return name in self._tasks
+        

--- a/test/test_tasks/test_bolt_conttest.py
+++ b/test/test_tasks/test_bolt_conttest.py
@@ -1,0 +1,76 @@
+"""
+"""
+import os.path
+import unittest
+
+import bolt.tasks.bolt_conttest as ct
+import _mocks as mck
+
+
+class TestRegisterTasks(unittest.TestCase):
+    
+    def test_registers_conttest_task(self):
+        registry = mck.TaskRegistryDouble()
+        ct.register_tasks(registry)
+        self.assertTrue(registry.contains('conttest'))
+        
+
+class TestExecuteConttest(unittest.TestCase):
+
+    def setUp(self):
+        self.subject = ExecuteConttestSpy()
+        return super(TestExecuteConttest, self).setUp()
+
+    def test_executes_configured_task(self):
+        task_name = 'configured'
+        config = {
+            'task': task_name
+        }
+        self.given_configuration(config)
+        self.expect_task(task_name)
+
+
+    def test_monitors_specified_directory(self):
+        directory = os.path.join(os.getcwd(), 'foo')
+        config = {
+            'directory': directory
+        }
+        self.given_configuration(config)
+        self.expect_path(directory)
+
+
+    def test_default_to_current_directory_if_none_specified(self):
+        self.given_configuration({})
+        self.expect_path(os.getcwd())
+
+
+    def test_continue_on_error_is_set_to_true(self):
+        self.given_configuration({})
+        self.assertTrue(self.subject.continue_on_error)
+
+
+    def given_configuration(self, config):
+        self.subject(config=config)
+
+
+    def expect_task(self, task):
+        self.assertEqual(self.subject.task_name, task)
+        
+
+
+    def expect_path(self, path):
+        self.assertEqual(self.subject.directory, path)
+
+
+
+class ExecuteConttestSpy(ct.ExecuteConttest):
+    
+    def execute_task(self): pass
+    
+
+    
+
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
This submission adds more coverage to the `conttest` task, so we have better verification. It also adds a registry double, so we can test module task registration.

