### PR TITLE
Implements Execution Context for Tasks

### DIFF
--- a/bolt/_btrunner.py
+++ b/bolt/_btrunner.py
@@ -10,6 +10,7 @@ class TaskRunner(object):
         self._config = config
         self._registry = registry
         self._continue_on_error = continue_on_error
+        self._context = {}
         self._script = None
         self._executed_operations = None
 
@@ -53,5 +54,5 @@ class TaskRunner(object):
 
     def _run_task(self, task):
         operation, config = task
-        result = operation(config=config)
+        result = operation(config=config, context=self._context)
         self._executed_operations.append(operation)


### PR DESCRIPTION
### Description
This submission implements a shared execution context passed to all executed tasks, so they can share data when needed. The context object has been implemented as a plain dictionary because it shares the interface of the configuration object making it easier to use, and it should be enough to meet the requirements.


##### Issue Fixes or Implemented Stories
#75  

