### PR TITLE
Prevents Swallow Exception Callstack

### DIFF
--- a/bolt/_btrunner.py
+++ b/bolt/_btrunner.py
@@ -44,12 +44,17 @@ class TaskRunner(object):
 
 
     def _try_run_task(self, task):
+        if self._continue_on_error:
+            self._run_task_protected(task)
+        else:
+            self._run_task(task)
+
+
+    def _run_task_protected(self, task):
         try:
             self._run_task(task)
         except Exception as ex:
-            logging.error(ex)
-            if not self._continue_on_error:
-                raise ex
+            logging.exception(ex)
 
 
     def _run_task(self, task):

--- a/bolt/about.py
+++ b/bolt/about.py
@@ -8,4 +8,4 @@ A task runner written in Python
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'
 version = u'0.2'
-release = u'0.2.1'
+release = u'0.2.2'


### PR DESCRIPTION
### Description
When a task raises an exception, we used to catch that exception, then evaluate if we should continue on error, and if we didn't, we will raise the same exception again. Unfortunately, this clears the original call stack, which doesn't help when debugging.

This is an initial fix to insure that if we are not continuing on error, that we don't even catch the exception. I also changed the logging to use the exception method.
