### PR TITLE
Fixes resolution of PIP entry point for PIP 10.x or higher

### DIFF
--- a/bolt/about.py
+++ b/bolt/about.py
@@ -8,4 +8,4 @@ A task runner written in Python
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'
 version = u'0.2'
-release = u'0.2.5'
+release = u'0.2.6'

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -44,6 +44,14 @@ import pip
 import bolt.errors as bterrors
 import bolt.utils as utilities
 
+major, minor, build = pip.__version__.split('.')
+major = int(major)
+if major >= 10:
+    import pip._internal
+    pip_entry_point = pip._internal.main
+else:
+    pip_entry_point = pip.main
+
 DEFAULT_COMMAND = 'install'
 DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 DEFAULT_ARGUMENTS = [DEFAULT_COMMAND, '-r', DEFAULT_REQUIREMENTS_FILE]
@@ -92,7 +100,7 @@ class ExecutePipTask(object):
 
 
     def _execute_pip(self):
-        pip.main(self.args)
+        pip_entry_point(self.args)
 
 
 


### PR DESCRIPTION
Fixes #96 caused by new index implementation of `pip` and its client. The issue happened because the main entry point to pip was moved from the root of the package to an `_internal` sub-package, so environments with `pip` 10.x or higher the entry point was not found.

I added a check for the pip version, and load the entry point from the correct location depending on that version.