### PR TITLE
Fixes retrieval of pip major version

### DIFF
--- a/bolt/about.py
+++ b/bolt/about.py
@@ -8,4 +8,4 @@ A task runner written in Python
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'
 version = u'0.2'
-release = u'0.2.7'
+release = u'0.2.8'

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -44,7 +44,7 @@ import pip
 import bolt.errors as bterrors
 import bolt.utils as utilities
 
-major, minor, build = pip.__version__.split('.')
+major = pip.__version__.split('.')[0]
 major = int(major)
 if major >= 10:
     import pip._internal


### PR DESCRIPTION
Fixes issue #100 due to a change in the pip version where the build number is not included. The fix described in the issue does not work for Python 2.7, so I went a simpler way to just get the major version by index.