### PR TITLE
Deprecated bolt.errors module

### DIFF
--- a/bolt/__init__.py
+++ b/bolt/__init__.py
@@ -1,7 +1,6 @@
 """
 This is the main module that exposes the required functions to use bolt in your applications.
 """
-import logging
 import sys
 
 import bolt._btapp as btapp

--- a/bolt/_btapp.py
+++ b/bolt/_btapp.py
@@ -1,6 +1,5 @@
 """
 """
-import logging
 import os.path
 
 import bolt._btconfig as btconfig

--- a/bolt/_btregistry.py
+++ b/bolt/_btregistry.py
@@ -2,7 +2,7 @@
 """
 import logging
 
-from bolt.errors import InvalidTaskError
+import bolt.api as api
 
 class TaskRegistry(object):
     """
@@ -19,7 +19,7 @@ class TaskRegistry(object):
         :return:
         """
         if not self._is_valid_task(task):
-            raise InvalidTaskError()
+            raise InvalidTaskTypeError(type(task))
         self._tasks[name] = task
         msg = '{task_name} task is registered.'.format(task_name=name)
         logging.debug(msg)
@@ -55,7 +55,16 @@ class TaskRegistry(object):
 
 
 
+class InvalidTaskTypeError(api.BoltError):
+    """
+    """
+    def __init__(self, task_type):
+        super(InvalidTaskTypeError, self).__init__(100)
+        self.task_type = task_type
 
+
+    def __repr__(self):
+        return 'InvalidTaskTypeError({t})'.format(t=self.task_type)
 
 
 

--- a/bolt/_btrunner.py
+++ b/bolt/_btrunner.py
@@ -1,7 +1,7 @@
 """
 """
 import logging
-import bolt.errors as bt_errors
+import bolt.api as api
 
 class TaskRunner(object):
     """
@@ -67,4 +67,4 @@ class TaskRunner(object):
 
     def _raise_if_not_none_or_zero(self, result):
         if result:
-            raise bt_errors.TaskError()
+            raise api.TaskFailedError()

--- a/bolt/api.py
+++ b/bolt/api.py
@@ -1,0 +1,98 @@
+"""
+This module contains classes that can be used for the implementation of 
+bolt tasks.
+"""
+
+
+class BoltError(Exception):
+    """
+    Base class for all exceptions in Bolt. The class is provided for inheritance
+    and it should not be used by itself.
+
+    Errors for the Bolt application itself should be derived from this class.
+    """
+    def __init__(self, code=1):
+        self.code = code
+
+
+    def __repr__(self):
+        return 'BoltError({code})'.format(code=self.code)
+
+
+    def __str__(self):
+        return repr(self)
+
+
+class TaskError(BoltError):
+    """
+    Base class for exceptions raised by a bolt task implementation. This class
+    is provided for inheritance and it should not be used by itself.
+
+    Exceptions derived from this class should be implemented to indicate errors
+    during the execution of a class. More specific exception base classes are
+    provided for the distinct processes of executing a class.
+
+    ..  seealso::
+        :class:`RequiredConfigurationError`
+        :class:`ConfigurationValueError`
+        :class:`TaskFailedError`
+    """
+    def __init__(self, code=999):
+        super(TaskError, self).__init__(code)
+
+
+    def __repr__(self):
+        return 'TaskError({code})'.format(code=self.code)
+
+
+class RequiredConfigurationError(TaskError):
+    """
+    Exception raised by tasks when a required configuration parameter is missing.
+
+    :param str parameter:
+        Name of the parameter missing.
+    """
+    def __init__(self, parameter):
+        super(RequiredConfigurationError, self).__init__(2)
+        self.parameter = parameter
+
+
+    def __repr__(self):
+        return 'RequiredConfigurationError({param})'.format(param=self.parameter)
+
+
+
+class ConfigurationValueError(TaskError):
+    """
+    Exception raised by tasks when the value of a configuration parameter is
+    invalid.
+
+    :param str parameter:
+        Name of the parameter that has an invalid value.
+    :param any value:
+        Invalid value specified.
+    """
+    def __init__(self, parameter, value):
+        super(ConfigurationValueError, self).__init__(3)
+        self.parameter = parameter
+        self.value = value
+
+
+    def __repr__(self):
+        return 'ConfigurationValueError({param}, {value})'.format(param=self.parameter, value=self.value)
+        
+
+
+class TaskFailedError(TaskError):
+    """
+    Exception to indicate that a task execution has failed. Tasks can choose
+    to raise this exception directly or derive from a more specific exception
+    to provide more information about the error.
+    """
+    def __init__(self, code=4):
+        super(TaskFailedError, self).__init__(code)
+
+
+    def __repr__(self):
+        return 'TaskFailedError({code})'.format(code=self.code)
+

--- a/bolt/errors.py
+++ b/bolt/errors.py
@@ -2,29 +2,8 @@
 This module defines exception classes used in the implementation of Bolt to
 report errors or as base classes to define other error conditions.
 """
-
-class BoltError(Exception):
-    """
-    Base class for all exceptons explicitely raised by Bolt.
-    """
-    def __init__(self, code=1):
-        self.code = code
-
-
-    def __str__(self):
-        return 'BoltError()'
-
-
-    def __repr__(self):
-        return self.__str__()
-
-
-
-class InvalidTaskError(BoltError):
-    """
-    TBD
-    """
-    pass
+print('WARNING!!! bolt.errors is deprecated. Use bolt.api for exceptions')
+from bolt.api import BoltError
 
 
 
@@ -33,7 +12,7 @@ class InvalidConfigurationError(BoltError):
     Base class for all task configuration errors.
     """
     
-    def __str__(self):
+    def __repr__(self):
         return 'InvalidConfigurationError()'
 
 
@@ -46,7 +25,7 @@ class ConfigurationParameterError(InvalidConfigurationError):
         self.parameter = param_name
 
 
-    def __str__(self):
+    def __repr__(self):
         return 'ConfigurationParameterError({pn})'.format(pn=repr(self.parameter))
 
 
@@ -58,7 +37,7 @@ class RequiredParameterMissingError(ConfigurationParameterError):
     configuration
     """
     
-    def __str__(self):
+    def __repr__(self):
         return 'RequiredParameterMissingError({pn})'.format(pn=repr(self.parameter))
 
 
@@ -73,7 +52,7 @@ class ConfigurationValueError(ConfigurationParameterError):
         self.value = value
 
 
-    def __str__(self):
+    def __repr__(self):
         fmt = 'ConfigurationValueError({pn}, {v})'
         return fmt.format(pn=repr(self.parameter), v=repr(self.value))
 
@@ -86,5 +65,5 @@ class TaskError(BoltError):
     execution of the task they are implementing.
     """
 
-    def __str__(self):
+    def __repr__(self):
         return 'TaskError()'

--- a/bolt/tasks/bolt_delete_files.py
+++ b/bolt/tasks/bolt_delete_files.py
@@ -61,7 +61,7 @@ import glob
 import logging
 import os
 
-import bolt.errors as bterrors
+import bolt.api as api
 import bolt.utils as utilities
 
 class DeleteFilesTask(object):
@@ -72,14 +72,12 @@ class DeleteFilesTask(object):
 
 
     def _set_valid_configuration(self, config):
-        if not config:
-            raise bterrors.InvalidConfigurationError('Configuration cannot be empty')
         self.sourcedir = config.get('sourcedir')
         if not self.sourcedir:
-            raise bterrors.RequiredParameterMissingError('sourcedir')
+            raise api.RequiredConfigurationError('sourcedir')
         self.pattern = config.get('pattern')
         if not self.pattern:
-            raise bterrors.RequiredParameterMissingError('pattern')
+            raise api.RequiredConfigurationError('pattern')
         self.recursive = config.get('recursive')
 
 

--- a/bolt/tasks/bolt_nose.py
+++ b/bolt/tasks/bolt_nose.py
@@ -26,34 +26,12 @@ import logging
 import os.path
 import subprocess as sp
 
-import bolt.errors as bterror
+import bolt.api as api
 import bolt.utils as utilities
 
 
 DEFAULT_DIR = './'
 DEFAULT_ARGUMENTS = [DEFAULT_DIR]
-
-
-class NoseError(bterror.TaskError):
-
-    def __init__(self, nose_code):
-        msg = "nose exited with code {code}".format(code=nose_code)
-        super(NoseError, self).__init__(msg)
-
-
-class _NoseArgumentGenerator(utilities.ArgumentsGenerator):
-
-    def __init__(self):
-        return super(_NoseArgumentGenerator, self).__init__(DEFAULT_ARGUMENTS, utilities.append_with_equal)
-
-
-    def _convert_config_to_arguments(self):
-        self.args.append('nosetests')
-        super(_NoseArgumentGenerator, self)._convert_config_to_arguments()
-        directory = self.config.get('directory') or DEFAULT_DIR
-        directory = os.path.abspath(directory)
-        self.args.append(directory)
-
 
 
 class ExecuteNoseTask(object):
@@ -74,7 +52,32 @@ class ExecuteNoseTask(object):
 
 
 
-
 def register_tasks(registry):
     registry.register_task('nose', ExecuteNoseTask())
+
+
+
+class NoseError(api.TaskFailedError):
+
+    def __init__(self, nose_code):
+        super(NoseError, self).__init__(nose_code)
+
+
+    def __repr__(self):
+        return 'NoseError({code})'.format(code=self.code)
+
+
+
+class _NoseArgumentGenerator(utilities.ArgumentsGenerator):
+
+    def __init__(self):
+        return super(_NoseArgumentGenerator, self).__init__(DEFAULT_ARGUMENTS, utilities.append_with_equal)
+
+
+    def _convert_config_to_arguments(self):
+        self.args.append('nosetests')
+        super(_NoseArgumentGenerator, self)._convert_config_to_arguments()
+        directory = self.config.get('directory') or DEFAULT_DIR
+        directory = os.path.abspath(directory)
+        self.args.append(directory)
 

--- a/bolt/tasks/bolt_setup.py
+++ b/bolt/tasks/bolt_setup.py
@@ -26,20 +26,11 @@ configure the task. ::
 import distutils.core as dcore
 import logging
 
-import bolt.errors as errors
+import bolt.api as api
 import bolt.utils as utilities
-
-
-class BuildSetupError(errors.TaskError): pass
 
 DEFAULT_ARGUMENTS = ['build']
 DEFAULT_SETUP_SCRIPT = 'setup.py'
-
-class _SetupArgumentGenerator(utilities.CommonCommandAndArgumentsGenerator):
-
-    def __init__(self):
-        return super(_SetupArgumentGenerator, self).__init__(DEFAULT_ARGUMENTS)
-
 
 
 class ExecuteSetupTask(object):
@@ -66,3 +57,17 @@ class ExecuteSetupTask(object):
 
 def register_tasks(registry):
     registry.register_task('setup', ExecuteSetupTask())
+
+
+
+class _SetupArgumentGenerator(utilities.CommonCommandAndArgumentsGenerator):
+
+    def __init__(self):
+        return super(_SetupArgumentGenerator, self).__init__(DEFAULT_ARGUMENTS)
+
+
+
+class BuildSetupError(api.TaskFailedError):
+
+    def __repr__(self):
+        return 'BuildSetupError({code})'.format(code=self.code)

--- a/bolt/tasks/bolt_shell.py
+++ b/bolt/tasks/bolt_shell.py
@@ -29,14 +29,7 @@ takes a few parameters::
 import logging
 import subprocess as sp
 
-import bolt.errors as bterror
-from bolt.errors import InvalidConfigurationError, RequiredParameterMissingError
-
-class ShellError(bterror.TaskError):
-
-    def __init__(self, shell_code):
-        msg = "shell command exited with code {code}".format(code=shell_code)
-        super(ShellError, self).__init__(msg)
+import bolt.api as api
 
 
 class ShellExecuteTask(object):
@@ -49,11 +42,9 @@ class ShellExecuteTask(object):
 
 
     def _verify_valid_configuration(self):
-        if not self.config:
-            raise InvalidConfigurationError('A shell command is required')
         self.command = self.config.get('command')
         if not self.command:
-            raise RequiredParameterMissingError('command')
+            raise api.RequiredConfigurationError('command')
 
 
     def _build_command_line(self):
@@ -74,3 +65,14 @@ class ShellExecuteTask(object):
 
 def register_tasks(registry):
     registry.register_task('shell', ShellExecuteTask())
+
+
+
+class ShellError(api.TaskFailedError):
+
+    def __init__(self, shell_code):
+        super(ShellError, self).__init__(shell_code)
+
+
+    def __repr__(self):
+        return 'ShellError({code})'.format(code=self.code)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,102 @@
+import unittest
+
+import bolt.api as api
+
+
+class TestBoltError(unittest.TestCase):
+
+    def setUp(self):
+        self.exception = api.BoltError()
+
+    def test_code_is_1_by_default(self):
+        self.assertEqual(self.exception.code, 1)
+
+
+    def test_code_can_be_specified(self):
+        self.assertEqual(api.BoltError(2).code, 2)
+
+
+    def test_provides_repr(self):
+        self.assertEqual(repr(self.exception), 'BoltError(1)')
+
+
+    def test_string_representation_uses_repr_by_default(self):
+        self.assertEqual(str(self.exception), repr(self.exception))
+
+
+
+class TestTaskError(unittest.TestCase):
+
+    def setUp(self):
+        self.exception = api.TaskError()
+
+    def test_code_is_999_by_default(self):
+        self.assertEqual(self.exception.code, 999)
+
+
+    def test_overrides_repr_to_show_generic_name(self):
+        self.assertEqual(repr(self.exception), 'TaskError(999)')
+
+
+
+
+class TestRequiredConfigurationError(unittest.TestCase):
+
+    def setUp(self):
+        self.param = 'param-name'
+        self.exception = api.RequiredConfigurationError(self.param)
+
+    def test_uses_code_2(self):
+        self.assertEqual(self.exception.code, 2)
+
+
+    def test_requires_parameter_name(self):
+        self.assertEqual(self.exception.parameter, self.param)
+
+
+    def test_shows_parameter_value_in_representation(self):
+        self.assertEqual(repr(self.exception), 'RequiredConfigurationError(param-name)')
+
+
+
+class TestConfigurationValueError(unittest.TestCase):
+
+    def setUp(self):
+        self.param = 'param'
+        self.value = 'value'
+        self.exception = api.ConfigurationValueError(self.param, self.value)
+
+
+    def test_uses_code_3(self):
+        self.assertEqual(self.exception.code, 3)
+
+
+    def test_requires_parameter_name(self):
+        self.assertEqual(self.exception.parameter, 'param')
+
+
+    def test_requires_error_value(self):
+        self.assertEqual(self.exception.value, self.value)
+
+
+    def test_shows_parameter_and_value_in_representation(self):
+        self.assertEqual(repr(self.exception), 'ConfigurationValueError(param, value)')
+
+
+
+class TestTaskFailedError(unittest.TestCase):
+
+    def setUp(self):
+        self.exception = api.TaskFailedError()
+
+    def test_uses_code_4(self):
+        self.assertEqual(self.exception.code, 4)
+
+
+    def test_overrides_repr_to_show_generic_name(self):
+        self.assertEqual(repr(self.exception), 'TaskFailedError(4)')
+
+
+
+if __name__=="__main__":
+    unittest.main()

--- a/test/test_btapp.py
+++ b/test/test_btapp.py
@@ -3,7 +3,7 @@ import os.path
 import unittest
 
 import bolt._btapp as btapp
-import bolt.errors as bterror
+import bolt.api as api
 import bolt._btregistry as btregistry
 
 
@@ -62,7 +62,7 @@ class TestBoltApplication(unittest.TestCase):
 
 
     def test_raises_system_exit_if_no_continue_on_error_set(self):
-        with self.assertRaises(bterror.TaskError):
+        with self.assertRaises(api.TaskFailedError):
             self.setup_tasks()
             self.application.run_task('continue')
             self.assertFalse(self.successful_task_executed)
@@ -78,7 +78,7 @@ class TestBoltApplication(unittest.TestCase):
         try:
             self.setup_tasks()
             self.application.run_task('insure_teardown')
-        except bterror.TaskError:
+        except api.TaskFailedError:
             self.assertTrue(self.tearable_task.tear_down_invoked)
 
 
@@ -124,7 +124,7 @@ class TestBoltApplication(unittest.TestCase):
 
 
     def failed_task(self, **kwargs):
-        raise bterror.TaskError()
+        raise api.TaskFailedError()
 
 
 

--- a/test/test_btregistry.py
+++ b/test/test_btregistry.py
@@ -1,6 +1,5 @@
 import unittest
 
-import bolt.errors as bterrors
 import bolt._btregistry as registry
 
 class TestTaskRegistry(unittest.TestCase):
@@ -8,11 +7,11 @@ class TestTaskRegistry(unittest.TestCase):
     def setUp(self):
         self.subject = registry.TaskRegistry()
 
+
     def test_can_register_callable_as_task(self):
         task_name = 'test'
         self.subject.register_task(task_name, self.test_callable)
         actual = self.subject.get(task_name)
-
         self.assertEqual(actual, self.test_callable)
 
 
@@ -21,17 +20,16 @@ class TestTaskRegistry(unittest.TestCase):
         task_list = ['task1', 'task2', 'task3']
         self.subject.register_task(task_name, task_list)
         actual_list = self.subject.get(task_name)
-
         self.assertSequenceEqual(task_list, actual_list)
 
 
     def test_fails_if_task_is_not_callable_or_list(self):
-        with self.assertRaises(bterrors.InvalidTaskError):
+        with self.assertRaises(registry.InvalidTaskTypeError):
             self.subject.register_task("invalid", 1)
 
 
     def test_raises_if_list_contains_anything_other_than_strings(self):
-        with self.assertRaises(bterrors.InvalidTaskError):
+        with self.assertRaises(registry.InvalidTaskTypeError):
             self.subject.register_task("invalid", ['foo', 'bar', 3])
 
 
@@ -40,7 +38,6 @@ class TestTaskRegistry(unittest.TestCase):
         subtask_name = 'test.sub'
         self.subject.register_task(task_name, self.test_callable)
         actual = self.subject.get(subtask_name)
-
         self.assertEqual(actual, self.test_callable)
 
 

--- a/test/test_btrunner.py
+++ b/test/test_btrunner.py
@@ -1,7 +1,7 @@
 import unittest
 
+import bolt.api as api
 import bolt._btconfig as config
-import bolt.errors as bterror
 import bolt._btregistry as registry
 
 import bolt._btrunner as runner
@@ -79,12 +79,12 @@ class TestTaskRunner(unittest.TestCase):
 
 
     def test_exits_if_task_raises_exception(self):
-        with self.assertRaises(bterror.TaskError):
+        with self.assertRaises(api.TaskFailedError):
             self.given('failing_task')
 
 
     def test_exits_if_task_does_not_return_zero(self):
-        with self.assertRaises(bterror.TaskError):
+        with self.assertRaises(api.TaskFailedError):
             self.given('failing_task_throug_return_code')
 
 
@@ -102,7 +102,7 @@ class TestTaskRunner(unittest.TestCase):
 
 
     def test_does_not_call_teardown_if_script_fails_before_executing_task(self):
-        with self.assertRaises(bterror.TaskError):
+        with self.assertRaises(api.TaskFailedError):
             self.given('partially_executed')
             self.assertFalse(self.tear_down_task.tear_down_called)
 
@@ -150,7 +150,7 @@ class TestTaskRunner(unittest.TestCase):
 
 
     def failing_task(self, **kwargs):
-        raise bterror.TaskError()
+        raise api.TaskFailedError()
 
 
     def failing_task_with_error_code(self, **kwargs):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -2,25 +2,6 @@ import unittest
 
 import bolt.errors as bt_errors
 
-class TestBoltError(unittest.TestCase):
-
-    def setUp(self):
-        super(TestBoltError, self).setUp()
-        self.exc = bt_errors.BoltError()
-
-
-    def test_code_is_1(self):
-        self.assertEqual(self.exc.code, 1)
-
-
-    def test_exception_as_string_shows_unknown_error(self):
-        self.assertEqual(str(self.exc), 'BoltError()')
-
-
-    def test_exception_representation_matches_string_representation(self):
-        self.assertEqual(repr(self.exc), str(self.exc))
-
-
 
 class TestInvalidTaskError(unittest.TestCase):
     # I need to check what InvalidTaskError is doing now, and evaluate if it

--- a/test/test_tasks/test_bolt_delete_files.py
+++ b/test/test_tasks/test_bolt_delete_files.py
@@ -1,6 +1,6 @@
 import unittest
 
-import bolt.errors as bterrors
+import bolt.api as api
 import bolt.tasks.bolt_delete_files as df
 import _mocks as mck
 
@@ -12,13 +12,8 @@ class TestDeleteFilesTask(unittest.TestCase):
         return super(TestDeleteFilesTask, self).setUp()
 
 
-    def test_raises_if_configuration_specified_is_empty(self):
-        with self.assertRaises(bterrors.InvalidConfigurationError):
-            self.subject(config={})
-
-
     def test_it_requires_a_root_folder(self):
-        with self.assertRaises(bterrors.InvalidConfigurationError):
+        with self.assertRaises(api.RequiredConfigurationError):
             config={
                     'pattern': '*.*',
                 }
@@ -26,7 +21,7 @@ class TestDeleteFilesTask(unittest.TestCase):
 
 
     def test_requires_a_file_pattern(self):
-        with self.assertRaises(bterrors.InvalidConfigurationError):
+        with self.assertRaises(api.RequiredConfigurationError):
             config={
                     'sourcedir': 'C:\\sourcedir',
                 }

--- a/test/test_tasks/test_bolt_shell.py
+++ b/test/test_tasks/test_bolt_shell.py
@@ -1,5 +1,6 @@
 import unittest
 
+import bolt.api as api
 import bolt.tasks.bolt_shell as bsh
 import _mocks as mck
 
@@ -11,12 +12,12 @@ class TestShellExecuteTask(unittest.TestCase):
 
 
     def test_configuration_cannot_be_empty(self):
-        with self.assertRaises(bsh.InvalidConfigurationError):
+        with self.assertRaises(api.RequiredConfigurationError):
             self.given({})
 
 
     def test_configuration_must_contain_command(self):
-        with self.assertRaises(bsh.InvalidConfigurationError):
+        with self.assertRaises(api.RequiredConfigurationError):
             config = {
                 'arguments': ['foo']
             }


### PR DESCRIPTION
I deprecated the `bolt.errors` module and add exception classes to `bolt.api`.