### PR TITLE
Fix bolt_pip entry point for pip>=19.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'

--- a/bolt/about.py
+++ b/bolt/about.py
@@ -3,7 +3,7 @@
 """
 project = u'bolt-ta'
 version = u'0.2'
-release = u'0.2.10'
+release = u'0.2.11'
 description = "A task runner written in Python"
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -45,9 +45,13 @@ import pip
 import bolt.api as api
 import bolt.utils as utilities
 
-major = pip.__version__.split('.')[0]
+major, minor, *ignore = pip.__version__.split('.')
 major = int(major)
-if major >= 10:
+minor = int(minor)
+if major >= 19 and minor >= 3:
+    import pip._internal.main
+    pip_entry_point = pip._internal.main.main
+elif major >= 10:
     import pip._internal
     pip_entry_point = pip._internal.main
 else:

--- a/bolt/tasks/bolt_pip.py
+++ b/bolt/tasks/bolt_pip.py
@@ -45,9 +45,9 @@ import pip
 import bolt.api as api
 import bolt.utils as utilities
 
-major, minor, *ignore = pip.__version__.split('.')
-major = int(major)
-minor = int(minor)
+pip_version_split = pip.__version__.split('.')
+major = int(pip_version_split[0])
+minor = int(pip_version_split[1])
 if major >= 19 and minor >= 3:
     import pip._internal.main
     pip_entry_point = pip._internal.main.main


### PR DESCRIPTION
The PR fixes bolt_pip after latest  [pip](https://github.com/pypa/pip) release 19.3. The main method has been moved into a separate module.
more info about [pip](https://github.com/pypa/pip) changes:
https://github.com/pypa/pip/commit/09fd200c599de4fadf2ff814a1bef855bc6d77e8#diff-77c4d7f6b635899eff3a6367e595a0c8