### PR TITLE
Fix the debug msg to be formatted using arguments in shell task

### DIFF
--- a/bolt/tasks/bolt_shell.py
+++ b/bolt/tasks/bolt_shell.py
@@ -42,7 +42,7 @@ class ShellExecuteTask(api.Task):
 
 
     def _execute(self):
-        logging.debug('Shell command line: ', repr(self.command_line))
+        logging.debug('Shell command line: %s', repr(self.command_line))
         result = sp.call(self.command_line)
         if result != 0:
             raise ShellError(result)


### PR DESCRIPTION
The logging module of python requires string formatter when using args with it.

https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L369