### PR TITLE
Fix teardown

### DIFF
--- a/bolt/_btrunner.py
+++ b/bolt/_btrunner.py
@@ -23,7 +23,7 @@ class TaskRunner(object):
 
 
     def tear_down(self):
-        for operation in self._executed_operations:
+        for operation in reversed(self._executed_operations):
             if hasattr(operation, 'tear_down'):
                 operation.tear_down()
 

--- a/bolt/about.py
+++ b/bolt/about.py
@@ -3,7 +3,7 @@
 """
 project = u'bolt-ta'
 version = u'0.3'
-release = u'0.3.2'
+release = u'0.3.3'
 description = "A task runner written in Python"
 copyright = u'2016 Abantos'
 author = u'Isaac Rodriguez'


### PR DESCRIPTION
The teardown call should be in a reversed order (stack) so that if a task depends on a previous task, should be teardown before the previous task

For example:
if we have task_1 that starts a webserver and task_2 that populate data
task_1 should be run before task_2
but at the same time task_1 should be teardown after task_2