### PR TITLE
Removes import dependency on distutils

### DIFF
--- a/bolt/about.py
+++ b/bolt/about.py
@@ -3,7 +3,7 @@
 """
 project = "bolt-ta"
 version = "0.3"
-release = "0.3.6"
+release = "0.3.7"
 description = "A task runner written in Python"
 copyright = "2016 Abantos"
 author = "Isaac Rodriguez"

--- a/bolt/tasks/bolt_setup.py
+++ b/bolt/tasks/bolt_setup.py
@@ -23,7 +23,7 @@ configure the task. ::
         }
     }
 """
-import distutils.core as dcore
+import logging
 
 import bolt.api as api
 import bolt.utils as utilities
@@ -41,14 +41,21 @@ class ExecuteSetupTask(api.Task):
             self.setup_script = DEFAULT_SETUP_SCRIPT
         generator = _SetupArgumentGenerator()
         self.args = generator.generate_from(self.config)
+        logging.debug(f'Setup script: {self.setup_script}')
+        logging.debug(f'Arguments: {self.args}')
 
     def _execute(self):
         result = self._execute_setup()
         if not result.dist_files:
             raise BuildSetupError()
 
-    def _execute_setup(self):
-        return dcore.run_setup(self.setup_script, self.args)
+    def _execute_setup(self):        
+        try:
+            import distutils.core as dcore
+            return dcore.run_setup(self.setup_script, self.args)
+        except ImportError:
+            logging.warning('Failed to import <distutils> please install the <setuptools> package.')
+            
 
 
 def register_tasks(registry):


### PR DESCRIPTION
The `distutils` module, which has been deprecated, was imported when the application executed, causing it to crash in Python 3.12 because `distutils` is no longer provided. As a temporary fix, I import the module when the `setup` task is used and executed, which will require `setuptools` to be installed, and `distutils` is included then.