### PR TITLE
Implements spawn task to execute command on separate process

### DIFF
--- a/.github/workflows/python-verify-library.yml
+++ b/.github/workflows/python-verify-library.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/test/test_tasks/test_bolt_shell.py
+++ b/test/test_tasks/test_bolt_shell.py
@@ -4,11 +4,12 @@ import bolt.api as api
 import bolt.tasks.bolt_shell as bsh
 import _mocks as mck
 
+FAIL_COMMAND = 'failed'
+
 
 class TestShellExecuteTask(unittest.TestCase):
     def setUp(self):
         self.subject = ShellExecuteTaskSpy()
-        return super(TestShellExecuteTask, self).setUp()
 
     def test_configuration_cannot_be_empty(self):
         with self.assertRaises(api.RequiredConfigurationError):
@@ -16,23 +17,23 @@ class TestShellExecuteTask(unittest.TestCase):
 
     def test_configuration_must_contain_command(self):
         with self.assertRaises(api.RequiredConfigurationError):
-            config = {"arguments": ["foo"]}
+            config = {'arguments': ['foo']}
             self.given(config)
 
     def test_command_line_contains_no_arguments_if_none_specified(self):
-        config = {"command": "ls"}
+        config = {'command': 'ls'}
         self.given(config)
-        self.expect_command_line(["ls"])
+        self.expect_command_line(['ls'])
 
     def test_command_line_contains_specified_arguments(self):
-        config = {"command": "command", "arguments": ["arg1", "arg2"]}
+        config = {'command': 'command', 'arguments': ['arg1', 'arg2']}
         self.given(config)
-        self.expect_command_line(["command", "arg1", "arg2"])
+        self.expect_command_line(['command', 'arg1', 'arg2'])
 
     def test_raises_if_command_fails(self):
         with self.assertRaises(Exception):
             config = {
-                "command": "failed",
+                'command': FAIL_COMMAND,
             }
             self.given(config)
 
@@ -48,23 +49,53 @@ class ShellExecuteTaskSpy(bsh.ShellExecuteTask):
         self.returncode = 0
         return super(ShellExecuteTaskSpy, self).__init__()
 
-    def _execute(self):
-        self.args = self.command_line
-        if self.args[0] == "failed":
-            self.returncode = 1
-        self.check_returncode()
+    def _invoke(self, command_line):
+        self.args = command_line
+        return 1 if self.args[0] == FAIL_COMMAND else 0
 
     def check_returncode(self):
         if self.returncode != 0:
-            raise Exception("Failed command")
+            raise Exception('Failed command')
+        
+
+class TestSpawnExecuteTask(unittest.TestCase):
+    def setUp(self):
+        self.subject = SpawnExecuteTaskSpy()
+        self.config = {
+            'command': 'spawned'
+        }
+
+    def test_raises_exception_if_creating_the_process_fails(self):
+        with self.assertRaises(bsh.ShellError):
+            self.subject(config={'command': 'failed'})
+
+    def test_terminates_process_on_tear_down(self):
+        self.subject(config=self.config)
+        self.subject.tear_down()
+        self.assertTrue(self.subject.process_terminated)
+        
+
+
+class SpawnExecuteTaskSpy(bsh.SpawnExecuteTask):
+    def __init__(self):
+        super().__init__()
+        self.process_terminated = False
+    
+    def _spawn_process(self, command_line):
+        if command_line[0] == FAIL_COMMAND: raise OSError(999, 'test error')
+        return self
+    
+    def terminate(self):
+        self.process_terminated = True
 
 
 class TestRegisterTasks(unittest.TestCase):
     def test_registers_shell(self):
         registry = mck.TaskRegistryDouble()
         bsh.register_tasks(registry)
-        self.assertTrue(registry.contains("shell"))
+        self.assertTrue(registry.contains('shell'))
+        self.assertTrue(registry.contains('spawn'))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This task allows to execute a command on a separate process without waiting for it to terminate. The process is terminated at the end. This is useful to launch a process that needs to keep running while other tasks complete (like executing a local server serving a system being tested).