### PR TITLE
Fix Task.__call__ to require config as positional argument

### DIFF
--- a/src/bolt/api.py
+++ b/src/bolt/api.py
@@ -9,8 +9,8 @@ import logging
 class Task:
     """ """
 
-    def __call__(self, **kwargs):
-        self.config = kwargs.get("config")
+    def __call__(self, config, **kwargs):
+        self.config = config
         self._configure()
         self._execute()
 


### PR DESCRIPTION
## Summary
Changed Task.__call__ method signature from accepting config as an optional keyword argument to requiring it as a positional parameter. This makes the config parameter mandatory and more explicit, improving the API design and preventing potential issues from missing config.

- Change signature from __call__(self, **kwargs) to __call__(self, config, **kwargs)
- Replace kwargs.get("config") with direct assignment of config parameter
